### PR TITLE
Search for both title and author

### DIFF
--- a/libgen_plugin.py
+++ b/libgen_plugin.py
@@ -59,7 +59,7 @@ class LibGen_Store(BasicStoreConfig, StorePlugin):
 
     def search(self, query, max_results=10, timeout=60):
         try:
-            results = lg.lookup(lg.search(query))
+            results = lg.lookup(lg.search(query, 'title') + lg.search(query, 'author'))
             print('Reached LibGen Mirrors.')
         except Exception as e:
             print(e)


### PR DESCRIPTION
pylibgen defaults to searching only by title. This change adds search by author. Calibre seems to ignore which box is which and just sends one search query (if I interpret the source code correctly).