### PR TITLE
fixed no results when searching

### DIFF
--- a/pylibgen.py
+++ b/pylibgen.py
@@ -156,5 +156,10 @@ class Library(object):
         if urlonly:
             return url
         r = requests.get(url)
+
+        # ugly patch for the decoder to properly detect the response as json
+        if r.content.startswith('id['):
+            r.content = r.content[2:]
+
         r.raise_for_status()
         return r


### PR DESCRIPTION
The response from [libgen.io](libgen.io) on a lookup operation is not valid JSON.
Other mirrors seem to work fine (that's why removing libgen.io from the MIRRORS arrays also does the trick as of #12).