### PR TITLE
Allow the use of multiple URLs to reach LibGenesis

### DIFF
--- a/libgen_plugin.py
+++ b/libgen_plugin.py
@@ -25,7 +25,7 @@ class LibGen_Store(BasicStoreConfig, StorePlugin):
 
 
     RES_THRESH = 5
-    url = 'http://gen.lib.rus.ec'
+    url = 'http://libgen.io'
 
     def open(self, parent=None, detail_item=None, external=False):
 


### PR DESCRIPTION
There might be a reason to allow LibGenesis to be reached by multiple URLs (e.g. DNS name resolution blocked).

It is not how I am imagining it right now, but I can build on top of this commit.